### PR TITLE
Add error message if zero files are detected

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ async function main() {
 
   const targets = glob.sync(target);
 
-  if (targets.length === 1) {
+  if (targets.length === 0) {
+    actions.error(`No item detected for glob ${target}`);
+  } else if (targets.length === 1) {
     const filename = targets[0].split('/').pop();
     uploadToDrive(filename, targets[0]);
   } else {


### PR DESCRIPTION
As described in the title of this PR, I added an error message if the configurable target glob does not match any files.
At the moment the action fails with a hard to read error message that zero files cannot be archived.